### PR TITLE
added getBackendName and refactor getName method

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,8 +1,8 @@
 # Release Notes für Nachnahme
 
-## X.X.X (2019-12-12)
+## X.X.X (2019-12-17)
 ### Geändert
-- Funktionalitäten hinzugefügt für Backend-Sichtbarkeiten
+- Funktionalitäten hinzugefügt für Backend-Sichtbarkeiten und Backend-Name
 
 ## 1.1.0 (2019-09-27)
 

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,8 +1,8 @@
 # Release Notes for Cash on delivery
 
-## X.X.X (2019-12-12)
+## X.X.X (2019-12-17)
 ### Changed
-- Added methods for the backend visibility
+- Added methods for the backend visibility and backend name
 
 ## 1.1.0 (2019-09-27)
 

--- a/src/Methods/CashOnDeliveryPaymentMethod.php
+++ b/src/Methods/CashOnDeliveryPaymentMethod.php
@@ -11,6 +11,7 @@ use Plenty\Modules\Frontend\Contracts\Checkout;
 use Plenty\Plugin\Application;
 use Plenty\Modules\Basket\Contracts\BasketRepositoryContract;
 use Plenty\Modules\Account\Contact\Contracts\ContactRepositoryContract;
+use Plenty\Plugin\Translation\Translator;
 
 /**
  * Class CashOnDeliveryPaymentMethod
@@ -43,18 +44,23 @@ class CashOnDeliveryPaymentMethod extends PaymentMethodService
      */
     protected $contactRepository;
 
+    /** @var Translator */
+    protected $translator;
+
     public function __construct(
         ConfigRepository $config,
         Checkout $checkout, 
         ParcelServicePresetRepositoryContract $parcelServicePresetRepoContract,
         BasketRepositoryContract $basketRepo,
-        ContactRepositoryContract $contactRepository)
+        ContactRepositoryContract $contactRepository,
+        Translator $translator)
     {
         $this->config = $config;
         $this->checkout = $checkout;
         $this->parcelServicePresetRepoContract = $parcelServicePresetRepoContract;
         $this->basketRepo = $basketRepo;
         $this->contactRepository = $contactRepository;
+        $this->translator = $translator;
     }
 
     /**
@@ -103,16 +109,7 @@ class CashOnDeliveryPaymentMethod extends PaymentMethodService
 
     public function getName($lang='de')
     {
-        $trans = pluginApp(\Plenty\Plugin\Translation\Translator::class);
-        $paymentMethodName = $trans->trans('CashOnDelivery::PaymentMethod.name');
-        if(strlen($paymentMethodName)){
-            return $paymentMethodName;
-        }
-        $name = $this->config->get('CashOnDelivery.name');
-        if(strlen($name) > 0) {
-            return $name;
-        } 
-        return 'cash on delivery';
+        return $this->translator->trans('CashOnDelivery::PaymentMethod.name',[],$lang);
     }
 
     public function getIcon()
@@ -154,5 +151,16 @@ class CashOnDeliveryPaymentMethod extends PaymentMethodService
     public function isBackendActive():bool
     {
         return true;
+    }
+
+    /**
+     * Get the name for the backend
+     *
+     * @param $lang
+     * @return string
+     */
+    public function getBackendName($lang):string
+    {
+        return $this->getName($lang);
     }
 }


### PR DESCRIPTION
GetName: `$this->config->get('CashOnDelivery.name');` wird nicht mehr benötigt, da es diese Option gar nicht beim Assistenten gibt und der Name über die Mehrsprachigkeit gepflegt wird. Der default Wert `return 'cash on delivery';` sollte auch überflüssig sein, da immer bereits standard Übersetzungen für Deutsch und Englisch hinterlegt sind. Siehe Lastschrift-Plugin zum Vergleich.
@plentymarkets/team-order-payment 
